### PR TITLE
Faster subtree split

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -221,26 +221,6 @@ travis_for_sites() {
     eval ${prepare_args/ /;}
     echo "travis_fold:end:subtree_pushes"
 
-    cd ./.subtree-clones/site-${SITE};
-    deploy_commit=$(git rev-parse ${DEPLOY_TAG})
-
-    # Update site-$SITE master branch whenever pushing to "sites" master
-    if [ "$TRAVIS_BRANCH" = "master" ]; then
-    git merge ${DEPLOY_TAG}
-    git push origin master
-    fi
-    cd ../..
-
-    cd ./.subtree-clones/site-common
-    deploy_common_commit=$(git rev-parse ${DEPLOY_COMMON_TAG})
-
-    # Update site-common master branch whenever pushing to "sites" master
-    if [ "$TRAVIS_BRANCH" = "master" ]; then
-    git merge ${DEPLOY_COMMON_TAG}
-    git push origin master
-    fi
-    cd ../..
-
     echo "Pushed tag $DEPLOY_TAG to site-$SITE and $DEPLOY_COMMON_TAG to site-common"
     echo "See the corresponding Travis run in site-$SITE for testing results."
 }

--- a/nifty-script
+++ b/nifty-script
@@ -218,6 +218,12 @@ travis_for_sites() {
 
     echo "travis_fold:start:subtree_pushes"
     prepare_args=$(./prepare-deploy "$mode" "$SITE" travis-${TRAVIS_BUILD_NUMBER})
+
+    # The output of the prepare-deploy script is a short list of
+    # space-separated NAME=VALUE pairs suitable for putting straight
+    # onto a command line. We want to get those values into the
+    # current environment, so we replace the spaces with semicolons
+    # and then "eval" the assignments.
     eval ${prepare_args/ /;}
     echo "travis_fold:end:subtree_pushes"
 


### PR DESCRIPTION
This is basically just tracking the changes of the faster-subtree-split PR in sites.

The sites repository won't be able to pass in travis, (after its faster-subtree-split PR lands), until these changes land as well.

The work to update the master branches in site-common and site-$site that is removed in this PR is added to the prepare-deploy script in the last commit of the sites PR.
