### PR TITLE
Stop running ansible-playbook with -vv

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -367,15 +367,8 @@ travis_for_separated_site_repository() {
 
     __ensure_reqs_and_decrypt
 
-    # Note: The -vv below is important for correctness. We have some
-    # long-running ansible tasks, (which are fired off asynchronously
-    # with periodic polling). The -vv here means that each poll
-    # attempt will produce some output. Without that, Travis might
-    # give up on the long tasks, (which it does if 10 minutes go by
-    # without any output).
-
     echo "travis_fold:start:deploy"
-    ANSIBLE_FLAGS="-vv" make deploy-${mode} DEPLOY_TAG=${TRAVIS_TAG} DEPLOY_COMMON_TAG=${SITE}-${TRAVIS_TAG}
+    make deploy-${mode} DEPLOY_TAG=${TRAVIS_TAG} DEPLOY_COMMON_TAG=${SITE}-${TRAVIS_TAG}
     echo "travis_fold:end:deploy"
 
     #####


### PR DESCRIPTION
With ansible 1.9 we found that it was necessary to add to get output
from ansible every time a polling test retried. This had some rather
unpleasant side effects, (such as emitting huge piles of data from
tasks that generated a lot of output on stdiout---bloating Travis logs
and causing it to give up on some of our deployments).

Fortunately, I've found that with Ansible >= 2.0, periodic polling
tasks emit a line each time they retry even without needing -vv.
