### PR TITLE
Bail out early for a production-tss tag

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -232,6 +232,11 @@ travis_for_sites() {
             echo "Exiting"
             return
         fi
+        if [ "$SITE" = "tss" ]; then
+            echo "Travis is not authorized to deploy to the tss site."
+            echo "Exiting"
+            return
+        fi
         ;;
     *)
         mode="feature"


### PR DESCRIPTION
We know that we can't deploy tss from Travis so we might as well bail
out early rather than running through the entire test suite just to
bail out at the end.
