### PR TITLE
Private pypi

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -493,8 +493,10 @@ verify_coverage_improvement() {
 #
 # This function assumes the following:
 #
-#	1. The app being tested has a "make travis-tests" target
-#	2. Either of the following are true:
+#
+#	1. The app being tested has a "make reqs" target
+#	2. The app being tested has a "make travis-tests" target
+#	3. Either of the following are true:
 #		a. The "make travis-tests" target generates .coverage
 #	     or b. The app has a "make coverage" target (in this case
 #                  the app's test suite will be run twice.
@@ -504,6 +506,17 @@ verify_coverage_improvement() {
 # pushed out to the app's repository.
 #####
 nifty_test_app() {
+
+    # Travis appears to have an ancient setuptools installed as part
+    # of its virtualenv. Recent versions of html5lib (at least as of
+    # version 0.999999999) require at least version 18.5 or above for
+    # setuptools. But since this isn't an expressed requirement, we
+    # need to manually upgrade setuptools rather than just trusting
+    # pip to do it for us as part of "make reqs"
+    pip install --upgrade setuptools
+
+    make reqs
+
     make travis-tests
 
     verify_coverage_improvement


### PR DESCRIPTION
A couple of things here:
1. Upgrade setuptools in nifty_test_app (so each app need not do that)
2. Allow for the PIP_EXTRA_INDEX_URL variable to be set to indicate an additional PyPi repository to use.

EDIT: Step 2 has been dropped. I realized that pip will read directly from the PIP_EXTRA_INDEX_URL variable, so there's no need to shove its value into ${HOME}/.pip/pip.conf
