### PR TITLE
Replace "set -e" at top of nifty-script

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-set -e
+# This is used instead of "set -e" because using "set -e" in a sourced script
+# can cause Travis builds to fail even if the script is sucessfully run.
+# See the issue below for more information:
+# https://github.com/travis-ci/travis-ci/issues/891#issuecomment-32318632
+trap 'exit' ERR
 
 NIFTY_GIT_CONFIG_EMAIL=${NIFTY_GIT_CONFIG_EMAIL:=carl.worth+travis@nimbisservices.com}
 NIFTY_TRAVIS_JOBS_URL_BASE=https://magnum.travis-ci.com/${TRAVIS_REPO_SLUG}/jobs


### PR DESCRIPTION
This is done because using "set -e" in a sourced script during a Travis
build can cause the builds to fail even if the souced script exits
successfully. For more information, see the link below:

https://github.com/travis-ci/travis-ci/issues/891#issuecomment-32318632