### PR TITLE
Fix travis

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 # This is used instead of "set -e" because using "set -e" in a sourced script
-# can cause Travis builds to fail even if the script is sucessfully run.
+# can cause Travis builds to fail even if the script is sucessfully run. Note
+# that "set -E" is different, and used to make the functions in this script
+# inherit the trap.
 # See the issue below for more information:
 # https://github.com/travis-ci/travis-ci/issues/891#issuecomment-32318632
+set -E
 trap 'exit' ERR
 
 NIFTY_GIT_CONFIG_EMAIL=${NIFTY_GIT_CONFIG_EMAIL:=carl.worth+travis@nimbisservices.com}

--- a/nifty-script
+++ b/nifty-script
@@ -7,7 +7,7 @@
 # See the issue below for more information:
 # https://github.com/travis-ci/travis-ci/issues/891#issuecomment-32318632
 set -E
-trap 'exit' ERR
+trap 'return 1' ERR
 
 NIFTY_GIT_CONFIG_EMAIL=${NIFTY_GIT_CONFIG_EMAIL:=carl.worth+travis@nimbisservices.com}
 NIFTY_TRAVIS_JOBS_URL_BASE=https://magnum.travis-ci.com/${TRAVIS_REPO_SLUG}/jobs


### PR DESCRIPTION
This doesn't fix Travis 100%, but it does leave it less broken than it currently is. These changes will allow Travis to report the actual build status of errors, failures, and successes.


## Current Behavior
Builds without this PR are currently terminating prematurely because of the "exit" that occurs (in both the cases of `set -e` and `trap 'exit' ERR; set -E`) bubbles up to the main Travis build process and then also run there. You can observe this by the fact that current builds on travis-ci.com do not end with `Done. Your build exited with ...` . We never reach the "real" end of the build process. We're simply getting travis to report an "error" (instead of the correct "fail") by immediately stopping the build process with our `exit`s.

## Behavior with this PR
The way in which this change still leaves the build broken is that although builds actually run to full completion and failures are now reported correctly, they don't occur "cleanly" (but this is the exact cause of the desired behavior). Here is an example of this:

https://travis-ci.com/nimbis/sites/jobs/67238578

```
pip install --upgrade -r requirements.txt
[31mInvalid requirement: '<<<<<<< HEAD'
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pip/req/req_install.py", line 82, in __init__
    req = Requirement(req)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pip/_vendor/packaging/requirements.py", line 96, in __init__
    requirement_string[e.loc:e.loc + 8]))
InvalidRequirement: Invalid requirement, parse error at "u'<<<<<<< '"
[0m
make[1]: *** [reqs] Error 1
make[1]: Leaving directory `/home/travis/build/nimbis/sites/tss'
make: *** [reqs] Error 2
/home/travis/build.sh: line 155: return: can only `return' from a function or sourced script

[31;1mThe command "travis_for_sites" exited with 2.[0m

Done. Your build exited with 1.
```