### PR TITLE
Disable deploys to production

### DIFF
--- a/nifty-script
+++ b/nifty-script
@@ -400,7 +400,9 @@ travis_for_sites() {
 
     echo "travis_fold:start:deploy"
     deploy_args=$(./prepare-deploy ${mode} ${SITE} ${TRAVIS_BUILD_NUMBER})
-    make -C ${SITE} deploy-${mode} ${deploy_args}
+    if [ $mode = "staging" ]; then
+        make -C ${SITE} deploy-staging ${deploy_args}
+    fi
     echo "travis_fold:end:deploy"
 
     #####


### PR DESCRIPTION
We want to be able to make releases (literally 'make release') with out
having this awake the Travis beast and deploying all over our production
server(s).

The releases are needed for our new deployment process, but we have yet
to take down the old servers.  Staging deploys will still work as
expected.